### PR TITLE
Remove unused compare-versions module (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# IntelliJ
+.idea
+
 *.pem

--- a/TheOrgBook/tob-web/package.json
+++ b/TheOrgBook/tob-web/package.json
@@ -27,7 +27,6 @@
     "@ngx-translate/core": "~8.0.0",
     "@ngx-translate/http-loader": "0.1.0",
     "bootstrap-sass": "~3.3.7",
-    "compare-versions": "^3.1.0",
     "core-js": "^2.4.1",
     "font-awesome": "^4.7.0",
     "localize-router": "git+https://github.com/cywolf/localize-router.git",

--- a/TheOrgBook/tob-web/src/app/roadmap/roadmap.component.ts
+++ b/TheOrgBook/tob-web/src/app/roadmap/roadmap.component.ts
@@ -4,7 +4,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { GeneralDataService } from 'app/general-data.service';
 import { Location, LocationType, VerifiableOrg, VerifiableOrgType, IssuerService, VerifiableClaim, VerifiableClaimType, DoingBusinessAs,
   blankLocation, blankOrgType, blankLocationType, blankIssuerService, blankClaimType } from '../data-types';
-import * as compareVersions from 'compare-versions';
 
 @Component({
   selector: 'app-roadmap',
@@ -67,7 +66,6 @@ export class RoadmapComponent implements OnInit {
             let sname = regType.schemaName;
             let other = typesBySchema[sname];
 
-            // if(other && compareVersions(regType.schemaVersion, other.schemaVersion) <= 0)
             if(other && other.id < regType.id)
               continue;
 


### PR DESCRIPTION
This module was causing builds of tob-web to fail, but it looks like the
code that used this module was comment out.  I've removed this module,
fixing the builds.

Fixes #5